### PR TITLE
Push layers before setup

### DIFF
--- a/Core/engine.cpp
+++ b/Core/engine.cpp
@@ -16,6 +16,11 @@ namespace GLStudy {
     // updates the current screen size based on the callback
     glfwSetFramebufferSizeCallback(window_, SizeCallback);
 
+    // Attach layers that were pushed before setup
+    for (Layer *layer : layer_stack_) {
+      layer->OnAttach();
+    }
+
     while (!glfwWindowShouldClose(window_)) {
       Update();
     }
@@ -37,7 +42,10 @@ namespace GLStudy {
   void Engine::PushLayer(Layer *layer)
   {
     layer_stack_.PushLayer(layer);
-    layer->OnAttach();
+    // If the engine is already initialized, immediately attach the layer
+    if (window_ != nullptr) {
+      layer->OnAttach();
+    }
   }
 
   void Engine::InitGLFW() {

--- a/Program/main.cpp
+++ b/Program/main.cpp
@@ -3,11 +3,12 @@
 
 int main() {
   GLStudy::Engine* engine = new GLStudy::Engine();
-  engine->Setup();
 
   // layers
   auto* layer = new GLStudy::ProgramLayer();
   engine->PushLayer(layer);
+
+  engine->Setup();
 
   //engine->Pause();
 


### PR DESCRIPTION
## Summary
- order layer initialization before engine setup
- attach pre-setup layers after creating the GL context
- don't attach layers until after setup unless the engine is already initialized

