### PR TITLE
Add EntityHandle cpp implementation

### DIFF
--- a/Assets/Shaders/simple_shader.frag
+++ b/Assets/Shaders/simple_shader.frag
@@ -1,7 +1,8 @@
 #version 330 core
 out vec4 FragColor;
+uniform vec4 u_Color;
 
 void main()
 {
-    FragColor = vec4(1.0f);
+    FragColor = u_Color;
 }

--- a/Assets/Shaders/simple_shader.vert
+++ b/Assets/Shaders/simple_shader.vert
@@ -1,7 +1,8 @@
 #version 330 core
 layout (location = 0) in vec3 aPos;
+uniform mat4 u_MVP;
 
 void main()
 {
-    gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);
+    gl_Position = u_MVP * vec4(aPos, 1.0);
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,19 @@ add_executable(openglStudy
         Core/Layer/LayerStack.cpp
         Core/Shader/Shader.h
         Core/Shader/Shader.cpp
+        Core/Scene/Components.h
+        Core/Scene/EntityHandle.h
+        Core/Scene/EntityHandle.cpp
+        Core/Scene/Scene.h
+        Core/Scene/Scene.cpp
+        Core/Graphics/VertexBuffer.h
+        Core/Graphics/VertexBuffer.cpp
+        Core/Graphics/VertexArray.h
+        Core/Graphics/VertexArray.cpp
+        Core/Graphics/IndexBuffer.h
+        Core/Graphics/IndexBuffer.cpp
+        Core/Graphics/Renderer.h
+        Core/Graphics/Renderer.cpp
 )
 
 target_include_directories(openglStudy PUBLIC

--- a/Core/Graphics/IndexBuffer.cpp
+++ b/Core/Graphics/IndexBuffer.cpp
@@ -1,0 +1,26 @@
+#include "IndexBuffer.h"
+
+namespace GLStudy {
+    IndexBuffer::IndexBuffer(const unsigned int* data, unsigned int count, GLenum usage)
+        : count_(count)
+    {
+        glGenBuffers(1, &renderer_id_);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, renderer_id_);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(unsigned int), data, usage);
+    }
+
+    IndexBuffer::~IndexBuffer()
+    {
+        glDeleteBuffers(1, &renderer_id_);
+    }
+
+    void IndexBuffer::Bind() const
+    {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, renderer_id_);
+    }
+
+    void IndexBuffer::Unbind() const
+    {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    }
+}

--- a/Core/Graphics/IndexBuffer.h
+++ b/Core/Graphics/IndexBuffer.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "glad/glad.h"
+
+namespace GLStudy {
+    class IndexBuffer {
+    public:
+        IndexBuffer(const unsigned int* data, unsigned int count, GLenum usage = GL_STATIC_DRAW);
+        ~IndexBuffer();
+
+        void Bind() const;
+        void Unbind() const;
+        unsigned int GetCount() const { return count_; }
+    private:
+        unsigned int renderer_id_ = 0;
+        unsigned int count_ = 0;
+    };
+}

--- a/Core/Graphics/Renderer.cpp
+++ b/Core/Graphics/Renderer.cpp
@@ -1,0 +1,70 @@
+#include "Renderer.h"
+#include "VertexBuffer.h"
+#include "VertexArray.h"
+#include "IndexBuffer.h"
+#include <glm/gtc/type_ptr.hpp>
+
+namespace GLStudy {
+    void Renderer::Init() {
+        shader_prog_ = Shader::CreateShaderProgram("Assets/Shaders/simple_shader.vert", "Assets/Shaders/simple_shader.frag");
+
+        // default VAO/VBO setup will happen per draw call
+        glUseProgram(shader_prog_);
+        mvp_location_ = glGetUniformLocation(shader_prog_, "u_MVP");
+        color_location_ = glGetUniformLocation(shader_prog_, "u_Color");
+    }
+
+    void Renderer::DrawTriangle(const glm::mat4& model, const glm::vec4& color, const glm::vec3 vertices[3]) {
+        static const unsigned int indices[3] = {0, 1, 2};
+
+        VertexArray va;
+        va.Bind();
+        VertexBuffer vb(vertices, sizeof(glm::vec3) * 3);
+        IndexBuffer ib(indices, 3);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), (void*)0);
+        glEnableVertexAttribArray(0);
+
+        glUseProgram(shader_prog_);
+        glm::mat4 mvp = model;
+        glUniformMatrix4fv(mvp_location_, 1, GL_FALSE, glm::value_ptr(mvp));
+        glUniform4fv(color_location_, 1, glm::value_ptr(color));
+
+        glDrawElements(GL_TRIANGLES, 3, GL_UNSIGNED_INT, nullptr);
+    }
+
+    void Renderer::DrawCube(const glm::mat4& model, const glm::vec4& color) {
+        const glm::vec3 vertices[] = {
+            {-0.5f, -0.5f, -0.5f},
+            { 0.5f, -0.5f, -0.5f},
+            { 0.5f,  0.5f, -0.5f},
+            {-0.5f,  0.5f, -0.5f},
+            {-0.5f, -0.5f,  0.5f},
+            { 0.5f, -0.5f,  0.5f},
+            { 0.5f,  0.5f,  0.5f},
+            {-0.5f,  0.5f,  0.5f}
+        };
+
+        const unsigned int indices[] = {
+            0,1,2, 2,3,0,
+            4,5,6, 6,7,4,
+            0,4,7, 7,3,0,
+            1,5,6, 6,2,1,
+            3,2,6, 6,7,3,
+            0,1,5, 5,4,0
+        };
+
+        VertexArray va;
+        va.Bind();
+        VertexBuffer vb(vertices, sizeof(vertices));
+        IndexBuffer ib(indices, 36);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(glm::vec3), (void*)0);
+        glEnableVertexAttribArray(0);
+
+        glUseProgram(shader_prog_);
+        glm::mat4 mvp = model;
+        glUniformMatrix4fv(mvp_location_, 1, GL_FALSE, glm::value_ptr(mvp));
+        glUniform4fv(color_location_, 1, glm::value_ptr(color));
+
+        glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, nullptr);
+    }
+}

--- a/Core/Graphics/Renderer.h
+++ b/Core/Graphics/Renderer.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <memory>
+#include "glad/glad.h"
+#include "Core/Shader/Shader.h"
+#include <glm/glm.hpp>
+#include "Core/Scene/Components.h"
+
+namespace GLStudy {
+    class Renderer {
+    public:
+        Renderer() = default;
+        void Init();
+        void DrawTriangle(const glm::mat4& model, const glm::vec4& color,
+                          const glm::vec3 vertices[3]);
+        void DrawTriangle(const glm::mat4& model, const glm::vec4& color)
+        {
+            static const glm::vec3 default_vertices[3] = {
+                {-0.5f, -0.5f, 0.0f}, {0.5f, -0.5f, 0.0f}, {0.0f, 0.5f, 0.0f}};
+            DrawTriangle(model, color, default_vertices);
+        }
+        void DrawCube(const glm::mat4& model, const glm::vec4& color);
+    private:
+        unsigned int shader_prog_ = 0;
+        int mvp_location_ = -1;
+        int color_location_ = -1;
+    };
+}

--- a/Core/Graphics/VertexArray.cpp
+++ b/Core/Graphics/VertexArray.cpp
@@ -1,0 +1,23 @@
+#include "VertexArray.h"
+
+namespace GLStudy {
+    VertexArray::VertexArray()
+    {
+        glGenVertexArrays(1, &renderer_id_);
+    }
+
+    VertexArray::~VertexArray()
+    {
+        glDeleteVertexArrays(1, &renderer_id_);
+    }
+
+    void VertexArray::Bind() const
+    {
+        glBindVertexArray(renderer_id_);
+    }
+
+    void VertexArray::Unbind() const
+    {
+        glBindVertexArray(0);
+    }
+} // GLStudy

--- a/Core/Graphics/VertexArray.h
+++ b/Core/Graphics/VertexArray.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "glad/glad.h"
+
+namespace GLStudy
+{
+    class VertexArray
+    {
+    public:
+        VertexArray();
+        ~VertexArray();
+        void Bind() const;
+        void Unbind() const;
+
+    private:
+        unsigned int renderer_id_ = 0;
+    };
+} // GLStudy

--- a/Core/Graphics/VertexBuffer.cpp
+++ b/Core/Graphics/VertexBuffer.cpp
@@ -1,0 +1,25 @@
+#include "VertexBuffer.h"
+
+namespace GLStudy {
+    VertexBuffer::VertexBuffer(const void* data, unsigned int size, GLenum usage)
+    {
+        glGenBuffers(1, &renderer_id_);
+        glBindBuffer(GL_ARRAY_BUFFER, renderer_id_);
+        glBufferData(GL_ARRAY_BUFFER, size, data, usage);
+    }
+
+    VertexBuffer::~VertexBuffer()
+    {
+        glDeleteBuffers(1, &renderer_id_);
+    }
+
+    void VertexBuffer::Bind() const
+    {
+        glBindBuffer(GL_ARRAY_BUFFER, renderer_id_);
+    }
+
+    void VertexBuffer::Unbind() const
+    {
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+} // GLStudy

--- a/Core/Graphics/VertexBuffer.h
+++ b/Core/Graphics/VertexBuffer.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "glad/glad.h"
+
+namespace GLStudy
+{
+    class VertexBuffer
+    {
+    public:
+        VertexBuffer(const void* data, unsigned int size, GLenum usage = GL_STATIC_DRAW);
+        ~VertexBuffer();
+        void Bind() const;
+        void Unbind() const;
+
+    private:
+        unsigned int renderer_id_ = 0;
+    };
+} // GLStudy

--- a/Core/Scene/Components.h
+++ b/Core/Scene/Components.h
@@ -1,0 +1,50 @@
+#pragma once
+#include <string>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <entt/entt.hpp>
+#include "glad/glad.h"
+
+namespace GLStudy {
+    struct TagComponent {
+        std::string tag{"Entity"};
+    };
+
+    struct Transform {
+        glm::vec3 position{0.0f};
+        glm::vec3 rotation{0.0f};
+        glm::vec3 scale{1.0f};
+
+        entt::entity parent{entt::null};
+        entt::entity first_child{entt::null};
+        entt::entity next_sibling{entt::null};
+        entt::entity prev_sibling{entt::null};
+
+        glm::mat4 LocalMatrix() const {
+            glm::mat4 mat(1.0f);
+            mat = glm::translate(mat, position);
+            mat = glm::rotate(mat, rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
+            mat = glm::rotate(mat, rotation.y, glm::vec3(0.0f, 1.0f, 0.0f));
+            mat = glm::rotate(mat, rotation.z, glm::vec3(0.0f, 0.0f, 1.0f));
+            mat = glm::scale(mat, scale);
+            return mat;
+        }
+    };
+
+    enum class MeshType
+    {
+        Triangle = 0,
+        Cube = 1,
+        Model = 2
+    };
+
+    struct RendererComponent
+    {
+        MeshType mesh{MeshType::Triangle};
+        glm::vec4 color{1.0f};
+        bool depth_test{true};
+        bool culling{true};
+        GLenum cull_face{GL_BACK};
+        bool double_sided{false};
+    };
+}

--- a/Core/Scene/EntityHandle.cpp
+++ b/Core/Scene/EntityHandle.cpp
@@ -1,0 +1,75 @@
+#include "EntityHandle.h"
+#include "Scene.h"
+
+namespace GLStudy {
+
+EntityHandle::EntityHandle(entt::entity handle, Scene* scene)
+    : handle_(handle), scene_(scene) {}
+
+bool EntityHandle::Valid() const {
+    return scene_ && scene_->registry_.valid(handle_);
+}
+
+void EntityHandle::SetParent(EntityHandle parent) {
+    auto& tr = GetComponent<Transform>();
+    entt::entity new_parent = parent ? parent.handle_ : entt::null;
+    if (tr.parent == new_parent) return;
+
+    if (tr.parent != entt::null) {
+        auto& parent_tr = scene_->registry_.get<Transform>(tr.parent);
+        if (parent_tr.first_child == handle_)
+            parent_tr.first_child = tr.next_sibling;
+        if (tr.prev_sibling != entt::null)
+            scene_->registry_.get<Transform>(tr.prev_sibling).next_sibling = tr.next_sibling;
+        if (tr.next_sibling != entt::null)
+            scene_->registry_.get<Transform>(tr.next_sibling).prev_sibling = tr.prev_sibling;
+    }
+
+    tr.parent = new_parent;
+    tr.next_sibling = tr.prev_sibling = entt::null;
+
+    if (new_parent != entt::null) {
+        auto& parent_tr = scene_->registry_.get<Transform>(new_parent);
+        if (parent_tr.first_child != entt::null)
+            scene_->registry_.get<Transform>(parent_tr.first_child).prev_sibling = handle_;
+        tr.next_sibling = parent_tr.first_child;
+        parent_tr.first_child = handle_;
+    }
+}
+
+std::vector<EntityHandle> EntityHandle::GetChildren() const {
+    std::vector<EntityHandle> children;
+    const auto& tr = scene_->registry_.get<Transform>(handle_);
+    entt::entity child = tr.first_child;
+    while (child != entt::null) {
+        children.emplace_back(child, scene_);
+        child = scene_->registry_.get<Transform>(child).next_sibling;
+    }
+    return children;
+}
+
+void EntityHandle::SetPosition(const glm::vec3& position) {
+    GetComponent<Transform>().position = position;
+}
+
+glm::vec3 EntityHandle::GetPosition() const {
+    return scene_->registry_.get<Transform>(handle_).position;
+}
+
+void EntityHandle::SetRotation(const glm::vec3& rotation) {
+    GetComponent<Transform>().rotation = rotation;
+}
+
+glm::vec3 EntityHandle::GetRotation() const {
+    return scene_->registry_.get<Transform>(handle_).rotation;
+}
+
+void EntityHandle::SetScale(const glm::vec3& scale) {
+    GetComponent<Transform>().scale = scale;
+}
+
+glm::vec3 EntityHandle::GetScale() const {
+    return scene_->registry_.get<Transform>(handle_).scale;
+}
+
+} // namespace GLStudy

--- a/Core/Scene/EntityHandle.h
+++ b/Core/Scene/EntityHandle.h
@@ -1,0 +1,70 @@
+#pragma once
+#include <entt/entt.hpp>
+#include <vector>
+#include <glm/glm.hpp>
+#include <type_traits>
+#include "Components.h"
+
+namespace GLStudy {
+    class Scene;
+
+    class EntityHandle {
+    public:
+        EntityHandle() = default;
+        EntityHandle(entt::entity handle, Scene* scene);
+        EntityHandle(const EntityHandle&) = default;
+        EntityHandle& operator=(const EntityHandle&) = default;
+
+        template<typename T, typename... Args>
+        T& AddComponent(Args&&... args);
+
+        template<typename T>
+        void RemoveComponent();
+
+        template<typename T>
+        T& GetComponent();
+
+        void SetParent(EntityHandle parent);
+        std::vector<EntityHandle> GetChildren() const;
+
+        void SetPosition(const glm::vec3& position);
+        glm::vec3 GetPosition() const;
+        void SetRotation(const glm::vec3& rotation);
+        glm::vec3 GetRotation() const;
+        void SetScale(const glm::vec3& scale);
+        glm::vec3 GetScale() const;
+
+        bool Valid() const;
+        operator bool() const { return Valid(); }
+        entt::entity Raw() const { return handle_; }
+
+    private:
+        entt::entity handle_{entt::null};
+        Scene* scene_ = nullptr;
+
+        friend class Scene;
+    };
+}
+
+#include "Scene.h"
+
+namespace GLStudy {
+
+template<typename T, typename... Args>
+T& EntityHandle::AddComponent(Args&&... args) {
+    return scene_->registry_.emplace<T>(handle_, std::forward<Args>(args)...);
+}
+
+template<typename T>
+void EntityHandle::RemoveComponent() {
+    static_assert(!std::is_same_v<T, Transform>, "Transform component cannot be removed");
+    scene_->registry_.remove<T>(handle_);
+}
+
+template<typename T>
+T& EntityHandle::GetComponent() {
+    return scene_->registry_.get<T>(handle_);
+}
+
+} // namespace GLStudy
+

--- a/Core/Scene/Scene.cpp
+++ b/Core/Scene/Scene.cpp
@@ -1,0 +1,56 @@
+#include "Scene.h"
+#include "EntityHandle.h"
+#include "Core/Graphics/Renderer.h"
+#include <glad/glad.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+namespace GLStudy {
+
+EntityHandle Scene::CreateEntity(const std::string& name) {
+    entt::entity e = registry_.create();
+    EntityHandle handle{e, this};
+    registry_.emplace<Transform>(e);
+    registry_.emplace<TagComponent>(e, TagComponent{name});
+    return handle;
+}
+
+void Scene::Render(Renderer* renderer) {
+    auto view = registry_.view<Transform, RendererComponent>();
+    for (auto entity : view) {
+        auto& rc = view.get<RendererComponent>(entity);
+
+        if (rc.depth_test)
+            glEnable(GL_DEPTH_TEST);
+        else
+            glDisable(GL_DEPTH_TEST);
+
+        if (rc.double_sided || !rc.culling)
+            glDisable(GL_CULL_FACE);
+        else {
+            glEnable(GL_CULL_FACE);
+            glCullFace(rc.cull_face);
+        }
+
+        switch (rc.mesh) {
+        case MeshType::Cube:
+            renderer->DrawCube(GetWorldMatrix(entity), rc.color);
+            break;
+        case MeshType::Triangle:
+        default:
+            renderer->DrawTriangle(GetWorldMatrix(entity), rc.color);
+            break;
+        }
+    }
+}
+
+glm::mat4 Scene::GetWorldMatrix(entt::entity entity) const {
+    const auto& tr = registry_.get<Transform>(entity);
+    glm::mat4 mat = tr.LocalMatrix();
+    if (tr.parent != entt::null) {
+        mat = GetWorldMatrix(tr.parent) * mat;
+    }
+    return mat;
+}
+
+} // namespace GLStudy

--- a/Core/Scene/Scene.h
+++ b/Core/Scene/Scene.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <entt/entt.hpp>
+#include <string>
+#include "Components.h"
+
+namespace GLStudy {
+    class EntityHandle;
+    class Renderer;
+
+    class Scene {
+    public:
+        Scene() = default;
+        EntityHandle CreateEntity(const std::string& name = "Entity");
+
+        void Render(Renderer* renderer);
+
+        glm::mat4 GetWorldMatrix(entt::entity entity) const;
+
+        entt::registry registry_;
+    };
+}
+
+#include "EntityHandle.h"
+

--- a/Core/engine.cpp
+++ b/Core/engine.cpp
@@ -9,6 +9,7 @@ namespace GLStudy
 
     Engine::Engine(): window_(nullptr)
     {
+        renderer_ = std::make_unique<Renderer>();
     }
 
     void Engine::Setup()
@@ -16,6 +17,7 @@ namespace GLStudy
         InitGLFW();
         CreateWindow(width_, height_, "OpenGL Study");
         InitGLAD();
+        renderer_->Init();
 
         // updates the current screen size based on the callback
         glfwSetFramebufferSizeCallback(window_, SizeCallback);

--- a/Core/engine.h
+++ b/Core/engine.h
@@ -1,11 +1,13 @@
 #pragma once
 #include <iostream>
+#include <memory>
 #include <glm.hpp>
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include "Time.h"
 #include "Core/Layer/LayerStack.h"
+#include "Core/Graphics/Renderer.h"
 
 
 namespace GLStudy
@@ -39,6 +41,8 @@ namespace GLStudy
 
         void PushLayer(Layer* layer);
 
+        Renderer* GetRenderer() const { return renderer_.get(); }
+
     private:
         GLFWwindow* window_;
         int width_ = 800, height_ = 600;
@@ -46,6 +50,7 @@ namespace GLStudy
         Timestep timestep_;
         Time time_;
         float last_frame_time_ = 0.0f;
+        std::unique_ptr<Renderer> renderer_;
 
         void InitGLFW();
 

--- a/Program/Layers/ProgramLayer.cpp
+++ b/Program/Layers/ProgramLayer.cpp
@@ -1,12 +1,9 @@
 #include "ProgramLayer.h"
-
-#include <iostream>
-
-#include "Core/Shader/Shader.h"
+#include <glm/glm.hpp>
 
 namespace GLStudy
 {
-    ProgramLayer::ProgramLayer()
+    ProgramLayer::ProgramLayer(Engine* engine) : engine_(engine)
     {
         debug_name_ = "ProgramLayer";
     }
@@ -14,27 +11,13 @@ namespace GLStudy
     void ProgramLayer::OnAttach()
     {
         Layer::OnAttach();
-        shader_prog_ = Shader::CreateShaderProgram("Assets/Shaders/simple_shader.vert", "Assets/Shaders/simple_shader.frag");
-        // 1. create the vertex data
-        float vertices[] = {
-            -0.5f, -0.5f, 0.0f,
-            0.5f, -0.5f, 0.0f,
-            0.0f, 0.5f, 0.0f
-        };
-        // 2. create the vertex array object
-        glGenVertexArrays(1, &vao_);
-        glBindVertexArray(vao_);
+        entity_ = scene_.CreateEntity();
+        entity_.AddComponent<RendererComponent>();
 
-        // 3. create the vertex buffer object
-        glGenBuffers(1, &vbo_);
-        glBindBuffer(GL_ARRAY_BUFFER, vbo_);
-
-        // 4. copy the data to inside the created buffer
-        glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
-        glEnableVertexAttribArray(0);
-        glBindVertexArray(vao_);
-        glUseProgram(shader_prog_);
+        EntityHandle child = scene_.CreateEntity();
+        child.AddComponent<RendererComponent>();
+        child.SetPosition({1.0f, 0.0f, 0.0f});
+        child.SetParent(entity_);
     }
 
     void ProgramLayer::OnDetach()
@@ -46,7 +29,8 @@ namespace GLStudy
     {
         Layer::OnUpdate(ts);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        glDrawArrays(GL_TRIANGLES, 0, 3);
+
+        scene_.Render(engine_->GetRenderer());
     }
 
     void ProgramLayer::OnImGuiRender()

--- a/Program/Layers/ProgramLayer.h
+++ b/Program/Layers/ProgramLayer.h
@@ -1,12 +1,14 @@
 #pragma once
 #include "Core/Layer/Layer.h"
+#include "Core/engine.h"
+#include "Core/Scene/Scene.h"
 
 namespace GLStudy
 {
     class ProgramLayer : public Layer
     {
     public:
-        ProgramLayer();
+        ProgramLayer(Engine* engine);
         ~ProgramLayer() = default;
         void OnAttach() override;
         void OnDetach() override;
@@ -14,6 +16,8 @@ namespace GLStudy
         void OnImGuiRender() override;
 
     private:
-        unsigned int vbo_, vao_, shader_prog_;
+        Engine* engine_;
+        Scene scene_;
+        EntityHandle entity_;
     };
 } // GLStudy

--- a/Program/main.cpp
+++ b/Program/main.cpp
@@ -5,7 +5,7 @@ int main() {
   GLStudy::Engine* engine = new GLStudy::Engine();
 
   // layers
-  auto* program_layer = new GLStudy::ProgramLayer();
+  auto* program_layer = new GLStudy::ProgramLayer(engine);
   engine->PushLayer(program_layer);
   engine->Setup();
   return 0;


### PR DESCRIPTION
## Summary
- move EntityHandle method definitions to `EntityHandle.cpp`
- keep template helpers in the header
- include new source in the build system

## Testing
- `cmake -S . -B build` *(fails: CMake 3.31 or higher is required)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6e6964c83329392a1538517c566