### PR TITLE
Implement Camera Controller system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ add_executable(openglStudy
         Core/Camera/Camera.h
         Core/Camera/SceneCamera.h
         Core/Camera/SceneCamera.cpp
+        Core/Camera/CameraController.h
+        Core/Camera/CameraController.cpp
         Core/Camera/EditorCamera.h
         Core/Camera/EditorCamera.cpp
         Core/Config.h

--- a/Core/Camera/CameraController.cpp
+++ b/Core/Camera/CameraController.cpp
@@ -1,0 +1,114 @@
+#include "CameraController.h"
+#include <glm.hpp>
+#include <gtc/matrix_transform.hpp>
+#include "Core/Scene/Components.h"
+
+namespace GLStudy {
+
+static void ApplyMouseMovement(CameraControllerComponent& cc, MouseMovedEvent& e) {
+    if (!cc.mouse_control_enabled)
+        return;
+    if (cc.first_mouse) {
+        cc.last_mouse_position = {e.GetX(), e.GetY()};
+        cc.first_mouse = false;
+    }
+
+    float xoffset = e.GetX() - cc.last_mouse_position.x;
+    float yoffset = cc.last_mouse_position.y - e.GetY();
+    cc.last_mouse_position = {e.GetX(), e.GetY()};
+
+    xoffset *= cc.rotation_speed;
+    yoffset *= cc.rotation_speed;
+
+    cc.yaw += xoffset;
+    cc.pitch += yoffset;
+
+    if (cc.pitch > 89.0f) cc.pitch = 89.0f;
+    if (cc.pitch < -89.0f) cc.pitch = -89.0f;
+}
+
+static void ApplyMouseScroll(CameraControllerComponent& cc, MouseScrolledEvent& e) {
+    float zoomAmount = e.GetYOffset() * cc.zoom_speed;
+    cc.movement_speed = std::max(1.0f, cc.movement_speed + zoomAmount);
+}
+
+static void ApplyKeyPressed(CameraControllerComponent& cc, KeyPressedEvent& e) {
+    switch (e.GetKeyCode()) {
+    case Key::W: cc.forward = true; break;
+    case Key::S: cc.backward = true; break;
+    case Key::A: cc.left = true; break;
+    case Key::D: cc.right = true; break;
+    case Key::Q: cc.up = true; break;
+    case Key::E: cc.down = true; break;
+    }
+}
+
+static void ApplyKeyReleased(CameraControllerComponent& cc, KeyReleasedEvent& e) {
+    switch (e.GetKeyCode()) {
+    case Key::W: cc.forward = false; break;
+    case Key::S: cc.backward = false; break;
+    case Key::A: cc.left = false; break;
+    case Key::D: cc.right = false; break;
+    case Key::Q: cc.up = false; break;
+    case Key::E: cc.down = false; break;
+    }
+}
+
+void CameraControllerSystem::OnEvent(Scene& scene, Event& e) {
+    EventDispatcher dispatcher(e);
+    dispatcher.Dispatch<MouseMovedEvent>([&](MouseMovedEvent& me){
+        auto view = scene.registry_.view<CameraControllerComponent>();
+        for (auto entity : view)
+            ApplyMouseMovement(view.get<CameraControllerComponent>(entity), me);
+        return false;
+    });
+    dispatcher.Dispatch<MouseScrolledEvent>([&](MouseScrolledEvent& me){
+        auto view = scene.registry_.view<CameraControllerComponent>();
+        for (auto entity : view)
+            ApplyMouseScroll(view.get<CameraControllerComponent>(entity), me);
+        return false;
+    });
+    dispatcher.Dispatch<KeyPressedEvent>([&](KeyPressedEvent& ke){
+        auto view = scene.registry_.view<CameraControllerComponent>();
+        for (auto entity : view)
+            ApplyKeyPressed(view.get<CameraControllerComponent>(entity), ke);
+        return false;
+    });
+    dispatcher.Dispatch<KeyReleasedEvent>([&](KeyReleasedEvent& ke){
+        auto view = scene.registry_.view<CameraControllerComponent>();
+        for (auto entity : view)
+            ApplyKeyReleased(view.get<CameraControllerComponent>(entity), ke);
+        return false;
+    });
+}
+
+void CameraControllerSystem::OnUpdate(Scene& scene, Timestep ts) {
+    auto view = scene.registry_.view<Transform, CameraControllerComponent>();
+    for (auto entity : view) {
+        auto& tr = view.get<Transform>(entity);
+        auto& cc = view.get<CameraControllerComponent>(entity);
+
+        glm::vec3 front{
+            cos(glm::radians(cc.yaw)) * cos(glm::radians(cc.pitch)),
+            sin(glm::radians(cc.pitch)),
+            sin(glm::radians(cc.yaw)) * cos(glm::radians(cc.pitch))
+        };
+        front = glm::normalize(front);
+        glm::vec3 right = glm::normalize(glm::cross(front, glm::vec3(0.0f,1.0f,0.0f)));
+        glm::vec3 up = glm::normalize(glm::cross(right, front));
+
+        glm::vec3 position = tr.position;
+        float velocity = cc.movement_speed * ts.GetSeconds();
+        if (cc.forward)  position += front * velocity;
+        if (cc.backward) position -= front * velocity;
+        if (cc.right)    position += right * velocity;
+        if (cc.left)     position -= right * velocity;
+        if (cc.up)       position += up * velocity;
+        if (cc.down)     position -= up * velocity;
+
+        tr.position = position;
+        tr.rotation = glm::vec3(glm::radians(cc.pitch), glm::radians(cc.yaw), 0.0f);
+    }
+}
+
+} // namespace GLStudy

--- a/Core/Camera/CameraController.h
+++ b/Core/Camera/CameraController.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "Core/TimeStep.h"
+#include "Core/Scene/Scene.h"
+#include "Core/Events/Event.h"
+#include "Core/Events/MouseEvent.h"
+#include "Core/Events/KeyEvent.h"
+
+namespace GLStudy {
+
+struct CameraControllerComponent {
+    enum class ControlMode { Fly = 0, Orbit, FirstPerson };
+
+    ControlMode mode = ControlMode::Fly;
+    float movement_speed = 5.0f;
+    float rotation_speed = 0.1f; // degrees per pixel
+    float zoom_speed = 1.0f;
+    float distance = 10.0f; // for orbit mode
+    bool mouse_control_enabled = true;
+
+    // internal state
+    bool forward = false;
+    bool backward = false;
+    bool left = false;
+    bool right = false;
+    bool up = false;
+    bool down = false;
+
+    bool first_mouse = true;
+    glm::vec2 last_mouse_position{0.0f};
+    float yaw = -90.0f;  // looking towards -Z
+    float pitch = 0.0f;
+};
+
+class CameraControllerSystem {
+public:
+    static void OnUpdate(Scene& scene, Timestep ts);
+    static void OnEvent(Scene& scene, Event& e);
+};
+
+} // namespace GLStudy

--- a/Core/Camera/SceneCamera.cpp
+++ b/Core/Camera/SceneCamera.cpp
@@ -2,6 +2,10 @@
 
 namespace GLStudy {
 
+SceneCamera::SceneCamera() {
+    RecalculateProjection();
+}
+
 void SceneCamera::SetPerspective(float fov, float near_clip, float far_clip) {
     projection_type_ = ProjectionType::Perspective;
     fov_ = fov;

--- a/Core/Camera/SceneCamera.h
+++ b/Core/Camera/SceneCamera.h
@@ -11,7 +11,7 @@ namespace GLStudy {
 
     class SceneCamera : public Camera {
     public:
-        SceneCamera() = default;
+        SceneCamera();
 
         void SetPerspective(float fov, float near_clip, float far_clip);
         void SetOrthographic(float size, float near_clip, float far_clip);
@@ -25,9 +25,9 @@ namespace GLStudy {
     private:
         ProjectionType projection_type_ = ProjectionType::Perspective;
         float aspect_ratio_ = 1.0f;
-        float fov_ = 45.0f;
+        float fov_ = 60.0f;
         float orthographic_size_ = 10.0f;
-        float near_clip_ = 0.1f;
+        float near_clip_ = 0.03f;
         float far_clip_ = 1000.0f;
 
         void RecalculateProjection();

--- a/Core/Scene/Scene.cpp
+++ b/Core/Scene/Scene.cpp
@@ -1,6 +1,7 @@
 #include "Scene.h"
 #include "EntityHandle.h"
 #include "Core/Graphics/Renderer.h"
+#include "Core/Camera/CameraController.h"
 #include <glad/glad.h>
 #include <glm.hpp>
 #include <gtc/matrix_transform.hpp>
@@ -13,6 +14,22 @@ EntityHandle Scene::CreateEntity(const std::string& name) {
     registry_.emplace<Transform>(e);
     registry_.emplace<TagComponent>(e, TagComponent{name});
     return handle;
+}
+
+void Scene::OnUpdate(Timestep ts) {
+    CameraControllerSystem::OnUpdate(*this, ts);
+}
+
+void Scene::OnEvent(Event& e) {
+    CameraControllerSystem::OnEvent(*this, e);
+}
+
+void Scene::OnViewportResize(float width, float height) {
+    auto view = registry_.view<CameraComponent>();
+    for (auto entity : view) {
+        auto& cc = view.get<CameraComponent>(entity);
+        cc.camera.SetViewportSize(width, height);
+    }
 }
 
 void Scene::Render(Renderer* renderer) {

--- a/Core/Scene/Scene.h
+++ b/Core/Scene/Scene.h
@@ -2,6 +2,8 @@
 #include <entt.hpp>
 #include <string>
 #include "Components.h"
+#include "Core/TimeStep.h"
+#include "Core/Events/Event.h"
 
 namespace GLStudy {
     class EntityHandle;
@@ -11,6 +13,10 @@ namespace GLStudy {
     public:
         Scene() = default;
         EntityHandle CreateEntity(const std::string& name = "Entity");
+
+        void OnUpdate(Timestep ts);
+        void OnEvent(Event& e);
+        void OnViewportResize(float width, float height);
 
         void Render(Renderer* renderer);
 

--- a/Core/engine.cpp
+++ b/Core/engine.cpp
@@ -24,6 +24,8 @@ namespace GLStudy
         InitGLAD();
         renderer_->Init();
 
+        scene_->OnViewportResize(width_, height_);
+
         InitCallbacks();
 
         initialization_state_ = EngineInitializationStates::INITIALIZED;
@@ -116,6 +118,7 @@ namespace GLStudy
         if (state_ != EngineStates::RUNNING)
             return;
 
+        scene_->OnUpdate(ts);
         UpdateLayers(ts);
     }
 
@@ -135,8 +138,11 @@ namespace GLStudy
             width_ = e.GetWidth();
             height_ = e.GetHeight();
             glViewport(0, 0, width_, height_);
+            scene_->OnViewportResize(width_, height_);
             return false;
         });
+
+        scene_->OnEvent(event);
 
         for (auto it = layer_stack_.rbegin(); it != layer_stack_.rend(); ++it)
         {

--- a/Program/Layers/ProgramLayer.cpp
+++ b/Program/Layers/ProgramLayer.cpp
@@ -16,9 +16,10 @@ namespace GLStudy
         entity_.AddComponent<RendererComponent>(MeshType::Cube);
 
         camera_ = scene_.CreateEntity("MainCamera");
-        auto camera_component = camera_.AddComponent<CameraComponent>();
+        camera_.AddComponent<CameraComponent>();
+        camera_.AddComponent<CameraControllerComponent>();
 
-        camera_.SetPosition({0.0f, 0.0f, 0.0f});
+        camera_.SetPosition({0.0f, 0.0f, 3.0f});
 
         EntityHandle child = scene_.CreateEntity();
         child.AddComponent<RendererComponent>();
@@ -38,12 +39,6 @@ namespace GLStudy
 
         float angle = Time::GetTime();
         entity_.SetRotation(glm::vec3(0.0f, 0.0f, sin(angle)));
-        camera_.GetComponent<CameraComponent>().camera.SetPerspective(90, 0.03f, 1000.0f);
-
-        float radius = 5.0f;
-        glm::vec3 cam_pos{0.0f, 0.0f, (sin(angle)+1.0) * radius};
-        camera_.SetPosition(cam_pos);
-        //camera_.SetRotation(glm::vec3(0.0f, -angle, 0.0f));
     }
 
     void ProgramLayer::OnImGuiRender()

--- a/Program/Layers/ProgramLayer.h
+++ b/Program/Layers/ProgramLayer.h
@@ -3,7 +3,9 @@
 #include "Core/engine.h"
 #include "Core/Scene/Scene.h"
 #include "Core/Camera/SceneCamera.h"
+#include "Core/Camera/CameraController.h"
 #include "Core/Events/KeyEvent.h"
+#include <unordered_map>
 
 namespace GLStudy
 {


### PR DESCRIPTION
## Summary
- add `CameraControllerComponent` and system to handle camera movement
- automatically update camera aspect on resize
- default `SceneCamera` values to 60 FOV and 0.03 near clip
- integrate camera controller with scene and engine
- update demo program layer to use new component

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6841e61add7483329b85e1c775179e44