### PR TITLE
Optimize renderer buffer usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Cmake-build-release/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #cmake-build-*
+/build

--- a/Assets/Shaders/simple_shader.frag
+++ b/Assets/Shaders/simple_shader.frag
@@ -1,8 +1,8 @@
 #version 330 core
+in vec4 vColor;
 out vec4 FragColor;
-uniform vec4 u_Color;
 
 void main()
 {
-    FragColor = u_Color;
+    FragColor = vColor;
 }

--- a/Assets/Shaders/simple_shader.vert
+++ b/Assets/Shaders/simple_shader.vert
@@ -1,8 +1,14 @@
 #version 330 core
-layout (location = 0) in vec3 aPos;
-uniform mat4 u_MVP;
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in mat4 aModel;
+layout(location = 5) in vec4 aColor;
+
+uniform mat4 u_ViewProjection;
+
+out vec4 vColor;
 
 void main()
 {
-    gl_Position = u_MVP * vec4(aPos, 1.0);
+    gl_Position = u_ViewProjection * aModel * vec4(aPos, 1.0);
+    vColor = aColor;
 }

--- a/Core/Graphics/Renderer.h
+++ b/Core/Graphics/Renderer.h
@@ -3,7 +3,11 @@
 #include "glad/glad.h"
 #include "Core/Shader/Shader.h"
 #include <glm.hpp>
+#include <vector>
 #include "Core/Scene/Components.h"
+#include "VertexArray.h"
+#include "VertexBuffer.h"
+#include "IndexBuffer.h"
 
 namespace GLStudy {
     class Renderer {
@@ -16,19 +20,29 @@ namespace GLStudy {
             view_projection_ = view_projection;
         }
 
-        void DrawTriangle(const glm::mat4& model, const glm::vec4& color,
-                          const glm::vec3 vertices[3]);
-        void DrawTriangle(const glm::mat4& model, const glm::vec4& color)
-        {
-            static const glm::vec3 default_vertices[3] = {
-                {-0.5f, -0.5f, 0.0f}, {0.5f, -0.5f, 0.0f}, {0.0f, 0.5f, 0.0f}};
-            DrawTriangle(model, color, default_vertices);
-        }
+        void DrawTriangle(const glm::mat4& model, const glm::vec4& color);
         void DrawCube(const glm::mat4& model, const glm::vec4& color);
+        void Flush();
     private:
+        struct InstanceData {
+            glm::mat4 model;
+            glm::vec4 color;
+        };
+
         unsigned int shader_prog_ = 0;
-        int mvp_location_ = -1;
-        int color_location_ = -1;
+        int view_proj_location_ = -1;
         glm::mat4 view_projection_{1.0f};
+
+        std::unique_ptr<VertexArray> triangle_vao_;
+        std::unique_ptr<VertexBuffer> triangle_vbo_;
+        std::unique_ptr<IndexBuffer> triangle_ibo_;
+        std::unique_ptr<VertexBuffer> triangle_instance_vbo_;
+        std::vector<InstanceData> triangle_instances_;
+
+        std::unique_ptr<VertexArray> cube_vao_;
+        std::unique_ptr<VertexBuffer> cube_vbo_;
+        std::unique_ptr<IndexBuffer> cube_ibo_;
+        std::unique_ptr<VertexBuffer> cube_instance_vbo_;
+        std::vector<InstanceData> cube_instances_;
     };
 }

--- a/Core/Graphics/VertexBuffer.cpp
+++ b/Core/Graphics/VertexBuffer.cpp
@@ -22,4 +22,10 @@ namespace GLStudy {
     {
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
+
+    void VertexBuffer::SetData(const void* data, unsigned int size) const
+    {
+        glBindBuffer(GL_ARRAY_BUFFER, renderer_id_);
+        glBufferData(GL_ARRAY_BUFFER, size, data, GL_DYNAMIC_DRAW);
+    }
 } // GLStudy

--- a/Core/Graphics/VertexBuffer.h
+++ b/Core/Graphics/VertexBuffer.h
@@ -10,6 +10,7 @@ namespace GLStudy
         ~VertexBuffer();
         void Bind() const;
         void Unbind() const;
+        void SetData(const void* data, unsigned int size) const;
 
     private:
         unsigned int renderer_id_ = 0;

--- a/Core/Scene/Scene.cpp
+++ b/Core/Scene/Scene.cpp
@@ -82,6 +82,7 @@ void Scene::Render(Renderer* renderer) {
             break;
         }
     }
+    renderer->Flush();
 }
 
 glm::mat4 Scene::GetWorldMatrix(entt::entity entity) const {


### PR DESCRIPTION
## Summary
- reuse VAO/VBO/IBO for triangle and cube meshes
- simplify DrawTriangle and DrawCube to bind precreated buffers
- SetData helper for VertexBuffer
- Add instancing buffers for batch rendering
- flush instanced batches in Scene

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6841f3278ecc83328462b042c71cb0f6