### PR TITLE
Implement occlusion culling

### DIFF
--- a/Assets/Shaders/occlusion_shader.frag
+++ b/Assets/Shaders/occlusion_shader.frag
@@ -1,0 +1,4 @@
+#version 330 core
+void main()
+{
+}

--- a/Assets/Shaders/occlusion_shader.vert
+++ b/Assets/Shaders/occlusion_shader.vert
@@ -1,0 +1,7 @@
+#version 330 core
+layout(location = 0) in vec3 aPos;
+uniform mat4 u_MVP;
+void main()
+{
+    gl_Position = u_MVP * vec4(aPos, 1.0);
+}

--- a/Core/Graphics/Renderer.h
+++ b/Core/Graphics/Renderer.h
@@ -37,6 +37,7 @@ namespace GLStudy {
 
         void DrawTriangle(const glm::mat4& model, const glm::vec4& color);
         void DrawCube(const glm::mat4& model, const glm::vec4& color);
+        bool PerformOcclusionQuery(const glm::mat4& model, MeshType mesh, unsigned int query);
         void Flush();
     private:
         struct InstanceData {
@@ -64,5 +65,8 @@ namespace GLStudy {
         std::vector<LightData> lights_;
         int cam_pos_location_ = -1;
         int num_lights_location_ = -1;
+
+        unsigned int occlusion_shader_prog_ = 0;
+        int occlusion_mvp_location_ = -1;
     };
 }

--- a/Core/Scene/Components.h
+++ b/Core/Scene/Components.h
@@ -70,5 +70,10 @@ namespace GLStudy {
         float inner_cutoff{12.5f};
         float outer_cutoff{17.5f};
     };
+
+    struct OcclusionComponent {
+        GLuint query{0};
+        bool visible{true};
+    };
 } // namespace GLStudy
 


### PR DESCRIPTION
## Summary
- create `OcclusionComponent` for query state
- add occlusion query support to Renderer
- create occlusion shaders
- cull invisible objects in Scene before batching

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/openglStudy` *(fails: `XDG_RUNTIME_DIR is invalid or not set`)*

------
https://chatgpt.com/codex/tasks/task_e_684363190e88833295a9f6b06eb9186b