### PR TITLE
Add Assimp-based model loading with texture support

### DIFF
--- a/Assets/Shaders/pbr_shader.frag
+++ b/Assets/Shaders/pbr_shader.frag
@@ -1,6 +1,7 @@
 #version 330 core
 in vec3 vPos;
 in vec3 vNormal;
+in vec3 vTangent;
 in vec4 vColor;
 in vec2 vTexCoord;
 
@@ -22,7 +23,9 @@ uniform int u_NumLights;
 uniform Light u_Lights[MAX_LIGHTS];
 uniform vec3 u_CamPos;
 uniform sampler2D u_AlbedoMap;
-uniform bool u_UseTexture;
+uniform sampler2D u_NormalMap;
+uniform bool u_UseAlbedoMap;
+uniform bool u_UseNormalMap;
 
 const float PI = 3.14159265359;
 
@@ -62,10 +65,18 @@ vec3 fresnelSchlick(float cosTheta, vec3 F0)
 
 void main()
 {
-    vec3 albedo = u_UseTexture ? texture(u_AlbedoMap, vTexCoord).rgb : vColor.rgb;
+    vec3 albedo = u_UseAlbedoMap ? texture(u_AlbedoMap, vTexCoord).rgb : vColor.rgb;
     float metallic = 0.8;
     float roughness = 0.3;
     vec3 N = normalize(vNormal);
+    vec3 T = normalize(vTangent);
+    vec3 B = normalize(cross(N, T));
+    if(u_UseNormalMap)
+    {
+        vec3 n = texture(u_NormalMap, vTexCoord).rgb * 2.0 - 1.0;
+        mat3 TBN = mat3(T, B, N);
+        N = normalize(TBN * n);
+    }
     vec3 V = normalize(u_CamPos - vPos);
     vec3 F0 = mix(vec3(0.04), albedo, metallic);
 

--- a/Assets/Shaders/pbr_shader.frag
+++ b/Assets/Shaders/pbr_shader.frag
@@ -2,6 +2,7 @@
 in vec3 vPos;
 in vec3 vNormal;
 in vec4 vColor;
+in vec2 vTexCoord;
 
 out vec4 FragColor;
 
@@ -20,6 +21,8 @@ struct Light {
 uniform int u_NumLights;
 uniform Light u_Lights[MAX_LIGHTS];
 uniform vec3 u_CamPos;
+uniform sampler2D u_AlbedoMap;
+uniform bool u_UseTexture;
 
 const float PI = 3.14159265359;
 
@@ -59,7 +62,7 @@ vec3 fresnelSchlick(float cosTheta, vec3 F0)
 
 void main()
 {
-    vec3 albedo = vColor.rgb;
+    vec3 albedo = u_UseTexture ? texture(u_AlbedoMap, vTexCoord).rgb : vColor.rgb;
     float metallic = 0.8;
     float roughness = 0.3;
     vec3 N = normalize(vNormal);

--- a/Assets/Shaders/pbr_shader.frag
+++ b/Assets/Shaders/pbr_shader.frag
@@ -24,8 +24,12 @@ uniform Light u_Lights[MAX_LIGHTS];
 uniform vec3 u_CamPos;
 uniform sampler2D u_AlbedoMap;
 uniform sampler2D u_NormalMap;
+uniform sampler2D u_MetallicMap;
+uniform sampler2D u_RoughnessMap;
 uniform bool u_UseAlbedoMap;
 uniform bool u_UseNormalMap;
+uniform bool u_UseMetallicMap;
+uniform bool u_UseRoughnessMap;
 
 const float PI = 3.14159265359;
 
@@ -66,8 +70,8 @@ vec3 fresnelSchlick(float cosTheta, vec3 F0)
 void main()
 {
     vec3 albedo = u_UseAlbedoMap ? texture(u_AlbedoMap, vTexCoord).rgb : vColor.rgb;
-    float metallic = 0.8;
-    float roughness = 0.3;
+    float metallic = u_UseMetallicMap ? texture(u_MetallicMap, vTexCoord).r : 0.8;
+    float roughness = u_UseRoughnessMap ? texture(u_RoughnessMap, vTexCoord).r : 0.3;
     vec3 N = normalize(vNormal);
     vec3 T = normalize(vTangent);
     vec3 B = normalize(cross(N, T));

--- a/Assets/Shaders/pbr_shader.vert
+++ b/Assets/Shaders/pbr_shader.vert
@@ -11,14 +11,17 @@ uniform mat4 u_Model;
 
 out vec3 vPos;
 out vec3 vNormal;
+out vec3 vTangent;
 out vec4 vColor;
 out vec2 vTexCoord;
 
 void main()
 {
     vec4 worldPos = u_Model * aModelTransform * vec4(aPos, 1.0);
+    mat3 normalMatrix = mat3(transpose(inverse(u_Model * aModelTransform)));
     vPos = worldPos.xyz;
-    vNormal = mat3(transpose(inverse(u_Model * aModelTransform))) * aNormal;
+    vNormal = normalMatrix * aNormal;
+    vTangent = normalMatrix * aTangent;
     vColor = aColor;
     vTexCoord = aTexCoord;
     gl_Position = u_ViewProjection * worldPos;

--- a/Assets/Shaders/pbr_shader.vert
+++ b/Assets/Shaders/pbr_shader.vert
@@ -7,16 +7,19 @@ layout(location = 4) in mat4 aModelTransform;
 layout(location = 8) in vec4 aColor;
 
 uniform mat4 u_ViewProjection;
+uniform mat4 u_Model;
 
 out vec3 vPos;
 out vec3 vNormal;
 out vec4 vColor;
+out vec2 vTexCoord;
 
 void main()
 {
-    vec4 worldPos = aModelTransform * vec4(aPos, 1.0);
+    vec4 worldPos = u_Model * aModelTransform * vec4(aPos, 1.0);
     vPos = worldPos.xyz;
     vNormal = mat3(transpose(inverse(aModelTransform))) * aNormal;
     vColor = aColor;
+    vTexCoord = aTexCoord;
     gl_Position = u_ViewProjection * worldPos;
 }

--- a/Assets/Shaders/pbr_shader.vert
+++ b/Assets/Shaders/pbr_shader.vert
@@ -18,7 +18,7 @@ void main()
 {
     vec4 worldPos = u_Model * aModelTransform * vec4(aPos, 1.0);
     vPos = worldPos.xyz;
-    vNormal = mat3(transpose(inverse(aModelTransform))) * aNormal;
+    vNormal = mat3(transpose(inverse(u_Model * aModelTransform))) * aNormal;
     vColor = aColor;
     vTexCoord = aTexCoord;
     gl_Position = u_ViewProjection * worldPos;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,12 @@ add_executable(openglStudy
         Core/Graphics/IndexBuffer.cpp
         Core/Graphics/Renderer.h
         Core/Graphics/Renderer.cpp
+        Core/Graphics/Texture.h
+        Core/Graphics/Texture.cpp
+        Core/Graphics/Mesh.h
+        Core/Graphics/Mesh.cpp
+        Core/Graphics/Model.h
+        Core/Graphics/Model.cpp
         Core/Camera/Camera.h
         Core/Camera/SceneCamera.h
         Core/Camera/SceneCamera.cpp

--- a/Core/Graphics/Mesh.cpp
+++ b/Core/Graphics/Mesh.cpp
@@ -3,8 +3,9 @@
 
 namespace GLStudy {
 
-Mesh::Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, std::shared_ptr<Texture2D> texture)
-    : texture_(std::move(texture)) {
+Mesh::Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices,
+           std::shared_ptr<Texture2D> albedo, std::shared_ptr<Texture2D> normal)
+    : albedo_(std::move(albedo)), normal_(std::move(normal)) {
     vao_ = std::make_unique<VertexArray>();
     vao_->Bind();
     vbo_ = std::make_unique<VertexBuffer>(vertices.data(), vertices.size() * sizeof(Vertex));
@@ -22,18 +23,27 @@ Mesh::Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>&
 }
 
 void Mesh::Draw(unsigned int shader) const {
-    if (texture_) {
-        glUniform1i(glGetUniformLocation(shader, "u_UseTexture"), 1);
+    if (albedo_) {
+        glUniform1i(glGetUniformLocation(shader, "u_UseAlbedoMap"), 1);
         glUniform1i(glGetUniformLocation(shader, "u_AlbedoMap"), 0);
-        texture_->Bind(0);
+        albedo_->Bind(0);
     } else {
-        glUniform1i(glGetUniformLocation(shader, "u_UseTexture"), 0);
+        glUniform1i(glGetUniformLocation(shader, "u_UseAlbedoMap"), 0);
+    }
+    if (normal_) {
+        glUniform1i(glGetUniformLocation(shader, "u_UseNormalMap"), 1);
+        glUniform1i(glGetUniformLocation(shader, "u_NormalMap"), 1);
+        normal_->Bind(1);
+    } else {
+        glUniform1i(glGetUniformLocation(shader, "u_UseNormalMap"), 0);
     }
     vao_->Bind();
     glDrawElements(GL_TRIANGLES, index_count_, GL_UNSIGNED_INT, nullptr);
     vao_->Unbind();
-    if (texture_)
-        texture_->Unbind();
+    if (albedo_)
+        albedo_->Unbind();
+    if (normal_)
+        normal_->Unbind();
 }
 
 }

--- a/Core/Graphics/Mesh.cpp
+++ b/Core/Graphics/Mesh.cpp
@@ -1,0 +1,39 @@
+#include "Mesh.h"
+#include <gtc/type_ptr.hpp>
+
+namespace GLStudy {
+
+Mesh::Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, std::shared_ptr<Texture2D> texture)
+    : texture_(std::move(texture)) {
+    vao_ = std::make_unique<VertexArray>();
+    vao_->Bind();
+    vbo_ = std::make_unique<VertexBuffer>(vertices.data(), vertices.size() * sizeof(Vertex));
+    ibo_ = std::make_unique<IndexBuffer>(indices.data(), indices.size());
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, position));
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, normal));
+    glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, tangent));
+    glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texcoord));
+    glEnableVertexAttribArray(0);
+    glEnableVertexAttribArray(1);
+    glEnableVertexAttribArray(2);
+    glEnableVertexAttribArray(3);
+    vao_->Unbind();
+    index_count_ = indices.size();
+}
+
+void Mesh::Draw(unsigned int shader) const {
+    if (texture_) {
+        glUniform1i(glGetUniformLocation(shader, "u_UseTexture"), 1);
+        glUniform1i(glGetUniformLocation(shader, "u_AlbedoMap"), 0);
+        texture_->Bind(0);
+    } else {
+        glUniform1i(glGetUniformLocation(shader, "u_UseTexture"), 0);
+    }
+    vao_->Bind();
+    glDrawElements(GL_TRIANGLES, index_count_, GL_UNSIGNED_INT, nullptr);
+    vao_->Unbind();
+    if (texture_)
+        texture_->Unbind();
+}
+
+}

--- a/Core/Graphics/Mesh.cpp
+++ b/Core/Graphics/Mesh.cpp
@@ -4,8 +4,10 @@
 namespace GLStudy {
 
 Mesh::Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices,
-           std::shared_ptr<Texture2D> albedo, std::shared_ptr<Texture2D> normal)
-    : albedo_(std::move(albedo)), normal_(std::move(normal)) {
+           std::shared_ptr<Texture2D> albedo, std::shared_ptr<Texture2D> normal,
+           std::shared_ptr<Texture2D> metallic, std::shared_ptr<Texture2D> roughness)
+    : albedo_(std::move(albedo)), normal_(std::move(normal)),
+      metallic_(std::move(metallic)), roughness_(std::move(roughness)) {
     vao_ = std::make_unique<VertexArray>();
     vao_->Bind();
     vbo_ = std::make_unique<VertexBuffer>(vertices.data(), vertices.size() * sizeof(Vertex));
@@ -37,6 +39,20 @@ void Mesh::Draw(unsigned int shader) const {
     } else {
         glUniform1i(glGetUniformLocation(shader, "u_UseNormalMap"), 0);
     }
+    if (metallic_) {
+        glUniform1i(glGetUniformLocation(shader, "u_UseMetallicMap"), 1);
+        glUniform1i(glGetUniformLocation(shader, "u_MetallicMap"), 2);
+        metallic_->Bind(2);
+    } else {
+        glUniform1i(glGetUniformLocation(shader, "u_UseMetallicMap"), 0);
+    }
+    if (roughness_) {
+        glUniform1i(glGetUniformLocation(shader, "u_UseRoughnessMap"), 1);
+        glUniform1i(glGetUniformLocation(shader, "u_RoughnessMap"), 3);
+        roughness_->Bind(3);
+    } else {
+        glUniform1i(glGetUniformLocation(shader, "u_UseRoughnessMap"), 0);
+    }
     vao_->Bind();
     glDrawElements(GL_TRIANGLES, index_count_, GL_UNSIGNED_INT, nullptr);
     vao_->Unbind();
@@ -44,6 +60,10 @@ void Mesh::Draw(unsigned int shader) const {
         albedo_->Unbind();
     if (normal_)
         normal_->Unbind();
+    if (metallic_)
+        metallic_->Unbind();
+    if (roughness_)
+        roughness_->Unbind();
 }
 
 }

--- a/Core/Graphics/Mesh.h
+++ b/Core/Graphics/Mesh.h
@@ -18,9 +18,12 @@ struct Vertex {
 class Mesh {
 public:
     Mesh() = default;
-    Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, std::shared_ptr<Texture2D> texture);
+    Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices,
+         std::shared_ptr<Texture2D> albedo,
+         std::shared_ptr<Texture2D> normal = nullptr);
     void Draw(unsigned int shader) const;
-    std::shared_ptr<Texture2D> texture_;
+    std::shared_ptr<Texture2D> albedo_;
+    std::shared_ptr<Texture2D> normal_;
 private:
     std::unique_ptr<VertexArray> vao_;
     std::unique_ptr<VertexBuffer> vbo_;

--- a/Core/Graphics/Mesh.h
+++ b/Core/Graphics/Mesh.h
@@ -20,10 +20,14 @@ public:
     Mesh() = default;
     Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices,
          std::shared_ptr<Texture2D> albedo,
-         std::shared_ptr<Texture2D> normal = nullptr);
+         std::shared_ptr<Texture2D> normal = nullptr,
+         std::shared_ptr<Texture2D> metallic = nullptr,
+         std::shared_ptr<Texture2D> roughness = nullptr);
     void Draw(unsigned int shader) const;
     std::shared_ptr<Texture2D> albedo_;
     std::shared_ptr<Texture2D> normal_;
+    std::shared_ptr<Texture2D> metallic_;
+    std::shared_ptr<Texture2D> roughness_;
 private:
     std::unique_ptr<VertexArray> vao_;
     std::unique_ptr<VertexBuffer> vbo_;

--- a/Core/Graphics/Mesh.h
+++ b/Core/Graphics/Mesh.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include <glm.hpp>
+#include "VertexArray.h"
+#include "VertexBuffer.h"
+#include "IndexBuffer.h"
+#include "Texture.h"
+
+namespace GLStudy {
+struct Vertex {
+    glm::vec3 position;
+    glm::vec3 normal;
+    glm::vec3 tangent;
+    glm::vec2 texcoord;
+};
+
+class Mesh {
+public:
+    Mesh() = default;
+    Mesh(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices, std::shared_ptr<Texture2D> texture);
+    void Draw(unsigned int shader) const;
+    std::shared_ptr<Texture2D> texture_;
+private:
+    std::unique_ptr<VertexArray> vao_;
+    std::unique_ptr<VertexBuffer> vbo_;
+    std::unique_ptr<IndexBuffer> ibo_;
+    unsigned int index_count_ = 0;
+};
+}

--- a/Core/Graphics/Model.cpp
+++ b/Core/Graphics/Model.cpp
@@ -4,6 +4,7 @@
 #include <assimp/postprocess.h>
 #include <glm.hpp>
 #include <gtc/type_ptr.hpp>
+#include <filesystem>
 #include <iostream>
 #include <cstdlib>
 
@@ -70,8 +71,12 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
                         }
                     }
                 } else {
-                    std::string filepath = directory_ + "/" + filename;
-                    tex = std::make_shared<Texture2D>(filepath);
+                    std::filesystem::path filePath = filename;
+                    if (!filePath.is_absolute())
+                        filePath = std::filesystem::path(directory_) / filePath;
+                    if (!std::filesystem::exists(filePath))
+                        filePath = std::filesystem::path(directory_) / filePath.filename();
+                    tex = std::make_shared<Texture2D>(filePath.string());
                 }
             }
         }

--- a/Core/Graphics/Model.cpp
+++ b/Core/Graphics/Model.cpp
@@ -12,8 +12,12 @@ namespace GLStudy {
 
 bool Model::LoadModel(const std::string& path) {
     Assimp::Importer importer;
-    const aiScene* scene = importer.ReadFile(path, aiProcess_Triangulate | aiProcess_GenSmoothNormals |
-                                             aiProcess_CalcTangentSpace);
+    const aiScene* scene = importer.ReadFile(
+        path,
+        aiProcess_Triangulate |
+        aiProcess_GenSmoothNormals |
+        aiProcess_CalcTangentSpace |
+        aiProcess_PreTransformVertices);
     if(!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
         std::cerr << "Assimp error: " << importer.GetErrorString() << std::endl;
         return false;
@@ -40,7 +44,9 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
     for(unsigned int i=0;i<mesh->mNumVertices;i++) {
         Vertex vertex{};
         vertex.position = {mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z};
-        vertex.normal = mesh->HasNormals() ? glm::vec3(mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z) : glm::vec3(0.0f);
+        vertex.normal = mesh->HasNormals() ?
+            glm::vec3(mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z) :
+            glm::vec3(0.0f);
         if(mesh->HasTangentsAndBitangents())
             vertex.tangent = {mesh->mTangents[i].x, mesh->mTangents[i].y, mesh->mTangents[i].z};
         if(mesh->mTextureCoords[0])
@@ -51,6 +57,26 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
         aiFace face = mesh->mFaces[i];
         for(unsigned int j=0;j<face.mNumIndices;j++)
             indices.push_back(face.mIndices[j]);
+    }
+
+    if(!mesh->HasNormals()) {
+        std::vector<glm::vec3> temp_normals(vertices.size(), glm::vec3(0.0f));
+        for(unsigned int i = 0; i < mesh->mNumFaces; ++i) {
+            const aiFace& face = mesh->mFaces[i];
+            if(face.mNumIndices < 3) continue;
+            unsigned int i0 = face.mIndices[0];
+            unsigned int i1 = face.mIndices[1];
+            unsigned int i2 = face.mIndices[2];
+            glm::vec3 v0 = vertices[i0].position;
+            glm::vec3 v1 = vertices[i1].position;
+            glm::vec3 v2 = vertices[i2].position;
+            glm::vec3 normal = glm::normalize(glm::cross(v1 - v0, v2 - v0));
+            temp_normals[i0] += normal;
+            temp_normals[i1] += normal;
+            temp_normals[i2] += normal;
+        }
+        for(size_t i = 0; i < vertices.size(); ++i)
+            vertices[i].normal = glm::normalize(temp_normals[i]);
     }
     std::shared_ptr<Texture2D> tex = nullptr;
     if(mesh->mMaterialIndex >=0) {

--- a/Core/Graphics/Model.cpp
+++ b/Core/Graphics/Model.cpp
@@ -116,14 +116,18 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
             }
         };
 
-        auto LoadTextureByName = [&](const std::string& hint) -> std::shared_ptr<Texture2D> {
+        auto LoadTextureByName = [&](std::initializer_list<std::string> hints) -> std::shared_ptr<Texture2D> {
             for(unsigned int i = 0; i < material->GetTextureCount(aiTextureType_UNKNOWN); ++i) {
                 aiString str; material->GetTexture(aiTextureType_UNKNOWN, i, &str);
                 std::string name = str.C_Str();
                 std::string lower;
                 lower.resize(name.size());
                 std::transform(name.begin(), name.end(), lower.begin(), ::tolower);
-                if(lower.find(hint) == std::string::npos)
+                bool match = false;
+                for(const auto& h : hints) {
+                    if(lower.find(h) != std::string::npos) { match = true; break; }
+                }
+                if(!match)
                     continue;
                 const aiTexture* texData = scene->GetEmbeddedTexture(name.c_str());
                 if(!texData && name[0] == '*') {
@@ -159,10 +163,10 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
             normalTex = LoadTextureOfType(aiTextureType_HEIGHT);
         metallicTex = LoadTextureOfType(aiTextureType_METALNESS);
         if(!metallicTex)
-            metallicTex = LoadTextureByName("metal");
+            metallicTex = LoadTextureByName({"metal", "spec"});
         roughnessTex = LoadTextureOfType(aiTextureType_DIFFUSE_ROUGHNESS);
         if(!roughnessTex)
-            roughnessTex = LoadTextureByName("rough");
+            roughnessTex = LoadTextureByName({"rough", "gloss"});
     }
     return Mesh(vertices, indices, albedoTex, normalTex, metallicTex, roughnessTex);
 }

--- a/Core/Graphics/Model.cpp
+++ b/Core/Graphics/Model.cpp
@@ -59,16 +59,18 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
             aiString str; material->GetTexture(aiTextureType_DIFFUSE,0,&str);
             std::string filename = str.C_Str();
             if(!filename.empty()) {
-                if(filename[0] == '*') {
+                const aiTexture* texData = scene->GetEmbeddedTexture(filename.c_str());
+                if(!texData && filename[0] == '*') {
                     int idx = std::atoi(filename.c_str() + 1);
-                    if(idx >= 0 && idx < static_cast<int>(scene->mNumTextures)) {
-                        const aiTexture* texData = scene->mTextures[idx];
-                        if(texData->mHeight == 0) {
-                            tex = std::make_shared<Texture2D>(reinterpret_cast<const unsigned char*>(texData->pcData), texData->mWidth);
-                        } else {
-                            tex = std::make_shared<Texture2D>();
-                            tex->LoadFromMemory(reinterpret_cast<const unsigned char*>(texData->pcData), texData->mWidth * texData->mHeight * 4);
-                        }
+                    if(idx >= 0 && idx < static_cast<int>(scene->mNumTextures))
+                        texData = scene->mTextures[idx];
+                }
+                if(texData) {
+                    if(texData->mHeight == 0) {
+                        tex = std::make_shared<Texture2D>(reinterpret_cast<const unsigned char*>(texData->pcData), texData->mWidth);
+                    } else {
+                        tex = std::make_shared<Texture2D>();
+                        tex->LoadFromRawData(reinterpret_cast<const unsigned char*>(texData->pcData), texData->mWidth, texData->mHeight, 4);
                     }
                 } else {
                     std::filesystem::path filePath = filename;

--- a/Core/Graphics/Model.cpp
+++ b/Core/Graphics/Model.cpp
@@ -80,6 +80,8 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
     }
     std::shared_ptr<Texture2D> albedoTex = nullptr;
     std::shared_ptr<Texture2D> normalTex = nullptr;
+    std::shared_ptr<Texture2D> metallicTex = nullptr;
+    std::shared_ptr<Texture2D> roughnessTex = nullptr;
     if(mesh->mMaterialIndex >=0) {
         aiMaterial* material = scene->mMaterials[mesh->mMaterialIndex];
         auto LoadTextureOfType = [&](aiTextureType type) -> std::shared_ptr<Texture2D> {
@@ -115,8 +117,10 @@ Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
         normalTex = LoadTextureOfType(aiTextureType_NORMALS);
         if(!normalTex)
             normalTex = LoadTextureOfType(aiTextureType_HEIGHT);
+        metallicTex = LoadTextureOfType(aiTextureType_METALNESS);
+        roughnessTex = LoadTextureOfType(aiTextureType_DIFFUSE_ROUGHNESS);
     }
-    return Mesh(vertices, indices, albedoTex, normalTex);
+    return Mesh(vertices, indices, albedoTex, normalTex, metallicTex, roughnessTex);
 }
 
 void Model::Draw(unsigned int shader, const glm::mat4& transform) const {

--- a/Core/Graphics/Model.cpp
+++ b/Core/Graphics/Model.cpp
@@ -13,7 +13,7 @@ namespace GLStudy {
 bool Model::LoadModel(const std::string& path) {
     Assimp::Importer importer;
     const aiScene* scene = importer.ReadFile(path, aiProcess_Triangulate | aiProcess_GenSmoothNormals |
-                                             aiProcess_FlipUVs | aiProcess_CalcTangentSpace);
+                                             aiProcess_CalcTangentSpace);
     if(!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
         std::cerr << "Assimp error: " << importer.GetErrorString() << std::endl;
         return false;

--- a/Core/Graphics/Model.cpp
+++ b/Core/Graphics/Model.cpp
@@ -1,0 +1,79 @@
+#include "Model.h"
+#include <assimp/Importer.hpp>
+#include <assimp/scene.h>
+#include <assimp/postprocess.h>
+#include <glm.hpp>
+#include <gtc/type_ptr.hpp>
+#include <iostream>
+
+namespace GLStudy {
+
+bool Model::LoadModel(const std::string& path) {
+    Assimp::Importer importer;
+    const aiScene* scene = importer.ReadFile(path, aiProcess_Triangulate | aiProcess_GenSmoothNormals |
+                                             aiProcess_FlipUVs | aiProcess_CalcTangentSpace);
+    if(!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode) {
+        std::cerr << "Assimp error: " << importer.GetErrorString() << std::endl;
+        return false;
+    }
+    directory_ = path.substr(0, path.find_last_of('/'));
+    meshes_.clear();
+    ProcessNode(scene->mRootNode, scene);
+    return true;
+}
+
+void Model::ProcessNode(aiNode* node, const aiScene* scene) {
+    for(unsigned int i=0;i<node->mNumMeshes;i++) {
+        aiMesh* mesh = scene->mMeshes[node->mMeshes[i]];
+        meshes_.push_back(ProcessMesh(mesh, scene));
+    }
+    for(unsigned int i=0;i<node->mNumChildren;i++) {
+        ProcessNode(node->mChildren[i], scene);
+    }
+}
+
+Mesh Model::ProcessMesh(aiMesh* mesh, const aiScene* scene) {
+    std::vector<Vertex> vertices;
+    std::vector<unsigned int> indices;
+    for(unsigned int i=0;i<mesh->mNumVertices;i++) {
+        Vertex vertex{};
+        vertex.position = {mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z};
+        vertex.normal = mesh->HasNormals() ? glm::vec3(mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z) : glm::vec3(0.0f);
+        if(mesh->HasTangentsAndBitangents())
+            vertex.tangent = {mesh->mTangents[i].x, mesh->mTangents[i].y, mesh->mTangents[i].z};
+        if(mesh->mTextureCoords[0])
+            vertex.texcoord = {mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y};
+        vertices.push_back(vertex);
+    }
+    for(unsigned int i=0;i<mesh->mNumFaces;i++) {
+        aiFace face = mesh->mFaces[i];
+        for(unsigned int j=0;j<face.mNumIndices;j++)
+            indices.push_back(face.mIndices[j]);
+    }
+    std::shared_ptr<Texture2D> tex = nullptr;
+    if(mesh->mMaterialIndex >=0) {
+        aiMaterial* material = scene->mMaterials[mesh->mMaterialIndex];
+        if(material->GetTextureCount(aiTextureType_DIFFUSE) > 0) {
+            aiString str; material->GetTexture(aiTextureType_DIFFUSE,0,&str);
+            std::string filename = str.C_Str();
+            std::string filepath = directory_ + "/" + filename;
+            tex = std::make_shared<Texture2D>(filepath);
+        }
+    }
+    return Mesh(vertices, indices, tex);
+}
+
+void Model::Draw(unsigned int shader, const glm::mat4& transform) const {
+    glUniformMatrix4fv(glGetUniformLocation(shader, "u_Model"), 1, GL_FALSE, glm::value_ptr(transform));
+    // set instance transform to identity
+    glm::mat4 identity(1.0f);
+    glVertexAttrib4fv(4, glm::value_ptr(identity[0]));
+    glVertexAttrib4fv(5, glm::value_ptr(identity[1]));
+    glVertexAttrib4fv(6, glm::value_ptr(identity[2]));
+    glVertexAttrib4fv(7, glm::value_ptr(identity[3]));
+    glVertexAttrib4f(8,1.0f,1.0f,1.0f,1.0f);
+    for(const auto& mesh : meshes_)
+        mesh.Draw(shader);
+}
+
+}

--- a/Core/Graphics/Model.h
+++ b/Core/Graphics/Model.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <vector>
+#include <memory>
+#include <string>
+#include "Mesh.h"
+
+struct aiNode;
+struct aiScene;
+struct aiMesh;
+namespace GLStudy {
+class Model {
+public:
+    bool LoadModel(const std::string& path);
+    void Draw(unsigned int shader, const glm::mat4& transform) const;
+private:
+    void ProcessNode(aiNode* node, const aiScene* scene);
+    Mesh ProcessMesh(aiMesh* mesh, const aiScene* scene);
+    std::vector<Mesh> meshes_;
+    std::string directory_;
+};
+}

--- a/Core/Graphics/Renderer.cpp
+++ b/Core/Graphics/Renderer.cpp
@@ -153,7 +153,8 @@ namespace GLStudy {
         glUniformMatrix4fv(model_location_, 1, GL_FALSE, glm::value_ptr(glm::mat4(1.0f)));
         glUniform3fv(cam_pos_location_, 1, glm::value_ptr(camera_pos_));
         glUniform1i(num_lights_location_, static_cast<int>(lights_.size()));
-        glUniform1i(glGetUniformLocation(shader_prog_, "u_UseTexture"), 0);
+        glUniform1i(glGetUniformLocation(shader_prog_, "u_UseAlbedoMap"), 0);
+        glUniform1i(glGetUniformLocation(shader_prog_, "u_UseNormalMap"), 0);
         for (size_t i = 0; i < lights_.size() && i < 4; ++i) {
             std::string base = "u_Lights[" + std::to_string(i) + "]";
             glUniform1i(glGetUniformLocation(shader_prog_, (base + ".type").c_str()), static_cast<int>(lights_[i].type));

--- a/Core/Graphics/Renderer.cpp
+++ b/Core/Graphics/Renderer.cpp
@@ -13,6 +13,7 @@ namespace GLStudy {
         view_proj_location_ = glGetUniformLocation(shader_prog_, "u_ViewProjection");
         cam_pos_location_ = glGetUniformLocation(shader_prog_, "u_CamPos");
         num_lights_location_ = glGetUniformLocation(shader_prog_, "u_NumLights");
+        model_location_ = glGetUniformLocation(shader_prog_, "u_Model");
 
         struct Vertex {
             glm::vec3 position;
@@ -149,6 +150,7 @@ namespace GLStudy {
     void Renderer::Flush() {
         glUseProgram(shader_prog_);
         glUniformMatrix4fv(view_proj_location_, 1, GL_FALSE, glm::value_ptr(view_projection_));
+        glUniformMatrix4fv(model_location_, 1, GL_FALSE, glm::value_ptr(glm::mat4(1.0f)));
         glUniform3fv(cam_pos_location_, 1, glm::value_ptr(camera_pos_));
         glUniform1i(num_lights_location_, static_cast<int>(lights_.size()));
         for (size_t i = 0; i < lights_.size() && i < 4; ++i) {

--- a/Core/Graphics/Renderer.cpp
+++ b/Core/Graphics/Renderer.cpp
@@ -155,6 +155,8 @@ namespace GLStudy {
         glUniform1i(num_lights_location_, static_cast<int>(lights_.size()));
         glUniform1i(glGetUniformLocation(shader_prog_, "u_UseAlbedoMap"), 0);
         glUniform1i(glGetUniformLocation(shader_prog_, "u_UseNormalMap"), 0);
+        glUniform1i(glGetUniformLocation(shader_prog_, "u_UseMetallicMap"), 0);
+        glUniform1i(glGetUniformLocation(shader_prog_, "u_UseRoughnessMap"), 0);
         for (size_t i = 0; i < lights_.size() && i < 4; ++i) {
             std::string base = "u_Lights[" + std::to_string(i) + "]";
             glUniform1i(glGetUniformLocation(shader_prog_, (base + ".type").c_str()), static_cast<int>(lights_[i].type));

--- a/Core/Graphics/Renderer.cpp
+++ b/Core/Graphics/Renderer.cpp
@@ -153,6 +153,7 @@ namespace GLStudy {
         glUniformMatrix4fv(model_location_, 1, GL_FALSE, glm::value_ptr(glm::mat4(1.0f)));
         glUniform3fv(cam_pos_location_, 1, glm::value_ptr(camera_pos_));
         glUniform1i(num_lights_location_, static_cast<int>(lights_.size()));
+        glUniform1i(glGetUniformLocation(shader_prog_, "u_UseTexture"), 0);
         for (size_t i = 0; i < lights_.size() && i < 4; ++i) {
             std::string base = "u_Lights[" + std::to_string(i) + "]";
             glUniform1i(glGetUniformLocation(shader_prog_, (base + ".type").c_str()), static_cast<int>(lights_[i].type));

--- a/Core/Graphics/Renderer.h
+++ b/Core/Graphics/Renderer.h
@@ -38,6 +38,7 @@ namespace GLStudy {
         void DrawTriangle(const glm::mat4& model, const glm::vec4& color);
         void DrawCube(const glm::mat4& model, const glm::vec4& color);
         void Flush();
+        unsigned int GetShaderProgram() const { return shader_prog_; }
     private:
         struct InstanceData {
             glm::mat4 model;
@@ -46,6 +47,7 @@ namespace GLStudy {
 
         unsigned int shader_prog_ = 0;
         int view_proj_location_ = -1;
+        int model_location_ = -1;
         glm::mat4 view_projection_{1.0f};
 
         std::unique_ptr<VertexArray> triangle_vao_;

--- a/Core/Graphics/Texture.cpp
+++ b/Core/Graphics/Texture.cpp
@@ -1,0 +1,52 @@
+#include "Texture.h"
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+#include <iostream>
+
+namespace GLStudy {
+Texture2D::Texture2D(const std::string& path) {
+    LoadFromFile(path);
+}
+
+bool Texture2D::LoadFromFile(const std::string& path) {
+    if(renderer_id_ != 0) {
+        glDeleteTextures(1, &renderer_id_);
+        renderer_id_ = 0;
+    }
+    stbi_set_flip_vertically_on_load(true);
+    unsigned char* data = stbi_load(path.c_str(), &width_, &height_, &channels_, 0);
+    if(!data) {
+        std::cerr << "Failed to load texture: " << path << std::endl;
+        return false;
+    }
+    GLenum format = GL_RGB;
+    if(channels_ == 4) format = GL_RGBA;
+    else if(channels_ == 3) format = GL_RGB;
+    else if(channels_ == 1) format = GL_RED;
+
+    glGenTextures(1, &renderer_id_);
+    glBindTexture(GL_TEXTURE_2D, renderer_id_);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexImage2D(GL_TEXTURE_2D, 0, format, width_, height_, 0, format, GL_UNSIGNED_BYTE, data);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    stbi_image_free(data);
+    return true;
+}
+
+Texture2D::~Texture2D() {
+    if(renderer_id_)
+        glDeleteTextures(1, &renderer_id_);
+}
+
+void Texture2D::Bind(unsigned int slot) const {
+    glActiveTexture(GL_TEXTURE0 + slot);
+    glBindTexture(GL_TEXTURE_2D, renderer_id_);
+}
+
+void Texture2D::Unbind() const {
+    glBindTexture(GL_TEXTURE_2D, 0);
+}
+}

--- a/Core/Graphics/Texture.cpp
+++ b/Core/Graphics/Texture.cpp
@@ -8,6 +8,10 @@ Texture2D::Texture2D(const std::string& path) {
     LoadFromFile(path);
 }
 
+Texture2D::Texture2D(const unsigned char* data, int size) {
+    LoadFromMemory(data, size);
+}
+
 bool Texture2D::LoadFromFile(const std::string& path) {
     if(renderer_id_ != 0) {
         glDeleteTextures(1, &renderer_id_);
@@ -33,6 +37,34 @@ bool Texture2D::LoadFromFile(const std::string& path) {
     glTexImage2D(GL_TEXTURE_2D, 0, format, width_, height_, 0, format, GL_UNSIGNED_BYTE, data);
     glGenerateMipmap(GL_TEXTURE_2D);
     stbi_image_free(data);
+    return true;
+}
+
+bool Texture2D::LoadFromMemory(const unsigned char* data, int size) {
+    if(renderer_id_ != 0) {
+        glDeleteTextures(1, &renderer_id_);
+        renderer_id_ = 0;
+    }
+    stbi_set_flip_vertically_on_load(true);
+    unsigned char* pixels = stbi_load_from_memory(data, size, &width_, &height_, &channels_, 0);
+    if(!pixels) {
+        std::cerr << "Failed to load texture from memory" << std::endl;
+        return false;
+    }
+    GLenum format = GL_RGB;
+    if(channels_ == 4) format = GL_RGBA;
+    else if(channels_ == 3) format = GL_RGB;
+    else if(channels_ == 1) format = GL_RED;
+
+    glGenTextures(1, &renderer_id_);
+    glBindTexture(GL_TEXTURE_2D, renderer_id_);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexImage2D(GL_TEXTURE_2D, 0, format, width_, height_, 0, format, GL_UNSIGNED_BYTE, pixels);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    stbi_image_free(pixels);
     return true;
 }
 

--- a/Core/Graphics/Texture.cpp
+++ b/Core/Graphics/Texture.cpp
@@ -68,6 +68,30 @@ bool Texture2D::LoadFromMemory(const unsigned char* data, int size) {
     return true;
 }
 
+bool Texture2D::LoadFromRawData(const unsigned char* data, int width, int height, int channels) {
+    if(renderer_id_ != 0) {
+        glDeleteTextures(1, &renderer_id_);
+        renderer_id_ = 0;
+    }
+    width_ = width;
+    height_ = height;
+    channels_ = channels;
+    GLenum format = GL_RGB;
+    if(channels_ == 4) format = GL_RGBA;
+    else if(channels_ == 3) format = GL_RGB;
+    else if(channels_ == 1) format = GL_RED;
+
+    glGenTextures(1, &renderer_id_);
+    glBindTexture(GL_TEXTURE_2D, renderer_id_);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexImage2D(GL_TEXTURE_2D, 0, format, width_, height_, 0, format, GL_UNSIGNED_BYTE, data);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    return true;
+}
+
 Texture2D::~Texture2D() {
     if(renderer_id_)
         glDeleteTextures(1, &renderer_id_);

--- a/Core/Graphics/Texture.h
+++ b/Core/Graphics/Texture.h
@@ -11,6 +11,7 @@ public:
     ~Texture2D();
     bool LoadFromFile(const std::string& path);
     bool LoadFromMemory(const unsigned char* data, int size);
+    bool LoadFromRawData(const unsigned char* data, int width, int height, int channels);
     void Bind(unsigned int slot = 0) const;
     void Unbind() const;
     int GetWidth() const { return width_; }

--- a/Core/Graphics/Texture.h
+++ b/Core/Graphics/Texture.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <string>
+#include "glad/glad.h"
+
+namespace GLStudy {
+class Texture2D {
+public:
+    Texture2D() = default;
+    explicit Texture2D(const std::string& path);
+    ~Texture2D();
+    bool LoadFromFile(const std::string& path);
+    void Bind(unsigned int slot = 0) const;
+    void Unbind() const;
+    int GetWidth() const { return width_; }
+    int GetHeight() const { return height_; }
+private:
+    unsigned int renderer_id_ = 0;
+    int width_ = 0;
+    int height_ = 0;
+    int channels_ = 0;
+};
+}

--- a/Core/Graphics/Texture.h
+++ b/Core/Graphics/Texture.h
@@ -7,8 +7,10 @@ class Texture2D {
 public:
     Texture2D() = default;
     explicit Texture2D(const std::string& path);
+    Texture2D(const unsigned char* data, int size);
     ~Texture2D();
     bool LoadFromFile(const std::string& path);
+    bool LoadFromMemory(const unsigned char* data, int size);
     void Bind(unsigned int slot = 0) const;
     void Unbind() const;
     int GetWidth() const { return width_; }

--- a/Core/Scene/Components.h
+++ b/Core/Scene/Components.h
@@ -5,6 +5,8 @@
 #include <entt.hpp>
 #include "glad/glad.h"
 #include "../Camera/SceneCamera.h"
+#include <memory>
+namespace GLStudy { class Model; }
 
 namespace GLStudy {
     struct TagComponent {
@@ -47,6 +49,10 @@ namespace GLStudy {
         bool culling{true};
         GLenum cull_face{GL_BACK};
         bool double_sided{false};
+    };
+
+    struct ModelComponent {
+        std::shared_ptr<Model> model;
     };
 
     struct CameraComponent

--- a/Core/Scene/Scene.cpp
+++ b/Core/Scene/Scene.cpp
@@ -1,6 +1,7 @@
 #include "Scene.h"
 #include "EntityHandle.h"
 #include "Core/Graphics/Renderer.h"
+#include "Core/Graphics/Model.h"
 #include "Core/Camera/CameraController.h"
 #include <glad/glad.h>
 #include <glm.hpp>
@@ -79,6 +80,7 @@ void Scene::Render(Renderer* renderer) {
     renderer->BeginScene(view_projection, cam_pos, lights);
 
     auto view = registry_.view<Transform, RendererComponent>();
+    auto model_view = registry_.view<Transform, ModelComponent>();
 
     glEnable(GL_BLEND);
     glEnable(GL_DEPTH_TEST);
@@ -102,6 +104,11 @@ void Scene::Render(Renderer* renderer) {
         }
     }
     renderer->Flush();
+    for (auto entity : model_view) {
+        auto& mc = model_view.get<ModelComponent>(entity);
+        if (mc.model)
+            mc.model->Draw(renderer->GetShaderProgram(), GetWorldMatrix(entity));
+    }
 }
 
 glm::mat4 Scene::GetWorldMatrix(entt::entity entity) const {

--- a/Program/Layers/ProgramLayer.cpp
+++ b/Program/Layers/ProgramLayer.cpp
@@ -53,6 +53,11 @@ namespace GLStudy
                                                           .color = glm::vec3(1.0f, 0.0f,0.0f),
                                                           .intensity = 10.0f});
         light_2_.SetPosition({0.0f, 0.0f,0.0f});
+
+        dummy_model_ = std::make_shared<Model>();
+        dummy_model_->LoadModel("Assets/Models/dummy.fbx");
+        model_entity_ = scene_.CreateEntity("DummyModel");
+        model_entity_.AddComponent<ModelComponent>(ModelComponent{dummy_model_});
     }
 
     void ProgramLayer::OnDetach()

--- a/Program/Layers/ProgramLayer.h
+++ b/Program/Layers/ProgramLayer.h
@@ -6,6 +6,7 @@
 #include "Core/Camera/CameraController.h"
 #include "Core/Events/KeyEvent.h"
 #include "Core/Scene/Components.h"
+#include "Core/Graphics/Model.h"
 #include <unordered_map>
 
 namespace GLStudy
@@ -29,6 +30,8 @@ namespace GLStudy
         EntityHandle light_;
         EntityHandle light_2_;
         EntityHandle camera_;
+        EntityHandle model_entity_;
+        std::shared_ptr<Model> dummy_model_;
         std::unordered_map<KeyCode, bool> last_key_state_map_;
 
         // debug controls


### PR DESCRIPTION
## Summary
- implement Texture2D wrapper using stb_image
- implement Mesh and Model classes for Assimp model loading
- add ModelComponent and use it in scene rendering
- extend PBR shader to support textures and model uniform
- load and render `dummy.fbx` as an example

## Testing
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6844a224af008332a4b61c578906b127