### PR TITLE
Fix Windows build with vcpkg integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,19 @@
 cmake_minimum_required(VERSION 3.11)
+
+# Automatically use the vcpkg toolchain on Windows when available. The
+# `setup.bat` script installs vcpkg in `%VCPKG_ROOT%` and users are expected to
+# run CMake with the toolchain file. To make configuration easier we detect the
+# environment variable and set `CMAKE_TOOLCHAIN_FILE` if it is not already
+# provided.
+if(WIN32 AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    if(DEFINED ENV{VCPKG_ROOT})
+        set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "Vcpkg toolchain" FORCE)
+        message(STATUS "Using vcpkg toolchain: ${CMAKE_TOOLCHAIN_FILE}")
+    else()
+        message(WARNING "VCPKG_ROOT environment variable not set. Run setup.bat first or specify -DVCPKG_ROOT=path")
+    endif()
+endif()
+
 project(openglStudy)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/setup.bat
+++ b/setup.bat
@@ -77,6 +77,9 @@ REM Persist VCPKG_ROOT so CMake can automatically find the toolchain later
 echo Setting VCPKG_ROOT environment variable for future terminals...
 setx VCPKG_ROOT "%VCPKG_ROOT%" >nul
 
+REM Also keep VCPKG_ROOT available in the current session
+endlocal & set VCPKG_ROOT=%VCPKG_ROOT%
+
 echo - Use CMake with:
 echo     -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
 echo   to automatically find these dependencies.

--- a/setup.bat
+++ b/setup.bat
@@ -72,6 +72,11 @@ echo ============================
 echo Setup complete!
 echo - Libraries installed via vcpkg:
 echo     assimp, boost-thread, boost-system, zlib, bullet3, glfw3, tinyexr
+
+REM Persist VCPKG_ROOT so CMake can automatically find the toolchain later
+echo Setting VCPKG_ROOT environment variable for future terminals...
+setx VCPKG_ROOT "%VCPKG_ROOT%" >nul
+
 echo - Use CMake with:
 echo     -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
 echo   to automatically find these dependencies.


### PR DESCRIPTION
## Summary
- detect `VCPKG_ROOT` on Windows and automatically set the vcpkg toolchain
- persist `VCPKG_ROOT` in `setup.bat` so CMake can find the toolchain later

## Testing
- `cmake -B build -S .`

------
https://chatgpt.com/codex/tasks/task_e_6847a048c53c833288389d986469165a