### PR TITLE
Fix event polling on main thread

### DIFF
--- a/Core/Physics/PhysicsWorld.h
+++ b/Core/Physics/PhysicsWorld.h
@@ -4,6 +4,7 @@
 #include "Core/TimeStep.h"
 #include <future>
 #include <memory>
+#include <mutex>
 #include "Core/Scene/EntityHandle.h"
 #include "Core/Scene/Components.h"
 
@@ -44,6 +45,8 @@ namespace GLStudy
         std::unique_ptr<btSequentialImpulseConstraintSolver> solver_;
         std::unique_ptr<btDefaultCollisionConfiguration> collisionConfiguration_;
         std::unique_ptr<btDiscreteDynamicsWorld> dynamics_world_;
+
+        mutable std::mutex world_mutex_;
 
     private:
         void Update(Timestep ts);

--- a/Core/engine.cpp
+++ b/Core/engine.cpp
@@ -97,7 +97,6 @@ namespace GLStudy
                     scene_->Render(GetRenderer());
                 }
                 glfwSwapBuffers(window_.get());
-                glfwPollEvents();
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         });
@@ -111,6 +110,7 @@ namespace GLStudy
             timestep_ = time - last_frame_time_;
             last_frame_time_ = time;
 
+            glfwPollEvents();
             Update(timestep_);
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }

--- a/Core/engine.cpp
+++ b/Core/engine.cpp
@@ -24,7 +24,11 @@ namespace GLStudy
             render_thread_.join();
         if (physics_thread_.joinable())
             physics_thread_.join();
-        delete scene_;
+        if (scene_)
+        {
+            delete scene_;
+            scene_ = nullptr;
+        }
     }
 
     void Engine::Setup()
@@ -121,6 +125,12 @@ namespace GLStudy
             render_thread_.join();
         if (physics_thread_.joinable())
             physics_thread_.join();
+
+        if (scene_)
+        {
+            delete scene_;
+            scene_ = nullptr;
+        }
 
         window_.reset();
         glfwTerminate();


### PR DESCRIPTION
## Summary
- avoid processing GLFW events on the render thread
- poll events on the main thread before updating the scene

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68488c4acc688329943599d1b4807a2c